### PR TITLE
Github Actions Enable Project

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+name: PlatformIO CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+          key: ${{ runner.os }}-pio
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install PlatformIO Core
+        run: pip install --upgrade platformio
+
+      - name: Build PlatformIO Project
+        run: pio run

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:genericCH32V003J4M6]
-platform = ch32v
+platform = https://github.com/Community-PIO-CH32V/platform-ch32v.git#2a620b07562894957e59228a99ce1c837ca08172
 board = genericCH32V003J4M6
 framework = noneos-sdk
 upload_protocol = wch-link ;wlink ;minichlink ;isp


### PR DESCRIPTION
Builds project in Github Actions.

Explicitly uses the Github URL for the platform, with a fixed Git hash for stability, so that no preinstallation of the ch32v platform is needed.